### PR TITLE
fix the acknowledgements link on footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,7 +77,7 @@ module.exports = {
             },
             {
               label: 'Acknowledgements',
-              href: 'docs/institutional/acknowledgements',
+              to: 'docs/institutional/acknowledgements',
             },
           ],
         },


### PR DESCRIPTION
# Description
I did a fixing on footer, because the link of 'Acknowledgements' was broken.

# Fixes 
 I replace the topic "href" by "to", and the bug was fixed. 


## Readiness Checklist

### Author/Contributor
- Isabela Alonso Martines

### Reviewing Maintainer
-  On footer of herbsjs.org, if you click of on the link Acknowledgements several times, the link will broke. After my modification, this does not happen anymore. 
