### PR TITLE
Changing the incorrect install command

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -14,10 +14,10 @@ To install and save in your package.json dependencies, run:
 
 ```bash
 # with npm
-npm install npm i @herbsjs/herbs
+npm install @herbsjs/herbs
 
 # with yarn
-yarn add npm i @herbsjs/herbs
+yarn add @herbsjs/herbs
 ```
 
 ## Using


### PR DESCRIPTION
Changing the incorrect install command
https://github.com/herbsjs/herbsjs.github.io/issues/56
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Changing incorrect install command 

![incorrect_command](https://user-images.githubusercontent.com/14333695/132362509-9290c7f5-ff28-400c-b42e-e53183dddb50.png)

To
![correct_command](https://user-images.githubusercontent.com/14333695/132362529-e1ad9190-a746-4e74-a3ee-3090aed4ce3e.png)


## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [x] `bug`
