### PR TITLE
fix: add correct link at "CONTRIBUTING" and "MIT License" in Herbs2gql Glue

### DIFF
--- a/docs/glues/herbs2gql.md
+++ b/docs/glues/herbs2gql.md
@@ -177,7 +177,7 @@ Come with us to make an awesome *herbs2gql*.
 
 Now, if you do not have the technical knowledge and also have intended to help us, do not feel shy, [click here](https://github.com/herbsjs/herbs2gql/issues) to open an issue and collaborate their ideas, the contribution may be a criticism or a compliment (why not?)
 
-If you would like to help contribute to this repository, please see [CONTRIBUTING](https://github.com/herbsjs/herbs2gql/blob/main/.github/CONTRIBUTING.md)
+If you would like to help contribute to this repository, please see [CONTRIBUTING](https://github.com/herbsjs/herbs2gql/blob/master/.github/CONTRIBUTING.md)
 
 ## License
 

--- a/docs/glues/herbs2gql.md
+++ b/docs/glues/herbs2gql.md
@@ -182,4 +182,4 @@ If you would like to help contribute to this repository, please see [CONTRIBUTIN
 ## License
 
 **herbsshelf** is released under the
-[MIT license](https://github.com/herbsjs/herbs2gql/blob/main/LICENSE.md)
+[MIT license](https://github.com/herbsjs/herbs2gql/blob/master/LICENSE)


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #87 
Fixes #88

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
