### PR TITLE
fix: change editUrl link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:
-            'https://github.com/herbsjs/herbsjs.github.io',
+          'https://github.com/herbsjs/herbsjs.github.io/blob/master',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Fix issue #86 

The "edit this page" link was redirecting to a page that does not exist.
