### PR TITLE
docs: add generateRoutesWithHerbarium in documentation

### DIFF
--- a/docs/glues/herbs2rest.md
+++ b/docs/glues/herbs2rest.md
@@ -15,13 +15,13 @@ Create a REST API based on herbs entities ([gotu](https://github.com/herbsjs/got
 ```
 ### Using
 
-Use the method generateRoutes to generate api rest routes based on usecases.
+Use the method generateRoutes or the generateRoutesWithHebarium to generate api rest routes based on usecases.
 
 herbs2rest works with [express](https://expressjs.com/) in version [4.x](https://expressjs.com/en/4x/api.html).
 
 #### Controller List
 
-The method needs a list of controllers like the example below:
+The default method (generateRoutes) needs a list of controllers like the example below:
 
 ```javascript
 const controllerList = [
@@ -80,6 +80,23 @@ const app = express()
 const routes = new express.Router()
 
 generateRoutes(controllerList, routes, true)  // true = console info endpoints
+
+app.use(routes)
+```
+
+#### Generate Routes With Herbarium
+
+As an alternative in a simpler way, if you already use Herbarium, a centralized and standardized repository and discovery service for Herbs objects, you can automatically generate and use new express routes:
+
+```javascript
+const express = require('express')
+const { herbarium } = require('@herbsjs/herbarium')
+const { generateRoutesWithHerbarium } = require('@herbsjs/herbs2rest')
+
+const app = express()
+const routes = new express.Router()
+
+generateRoutesWithHerbarium(herbarium, routes, true)  // true = console info endpoints
 
 app.use(routes)
 ```


### PR DESCRIPTION
Added documentation from herbs2rest related to creating endpoints with Herbarium (generateRoutesWithHerbarium).
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

[Implements documentation from /herbs2rest](https://github.com/herbsjs/herbs2rest/pull/25)

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
