### PR TITLE
Repository optional ids documentation 

### DIFF
--- a/docs/glues/herbs2knex.md
+++ b/docs/glues/herbs2knex.md
@@ -124,6 +124,25 @@ class YourRepository extends Repository {
     ids: [`customerId`, `productId`]  // productItem.customerId , productItem.productId
     ```
 
+    It's is possible to omit this field if the entity already has fields defined on it with `field` and the `isId` option or `id` helper functions:
+
+    ```javascript
+    // entity definition
+    const Order = entity('Order', {
+        orderSequence: field(Number, { isId: true }),
+        customerId: id(Number)
+    })
+
+    // repository definition
+    class OrderRepository extends Repository {
+        constructor({
+            entity: Order,
+            ids: ['orderSequence', 'customerId'] // `this` field is optional, since herbs can discover it through the entity metadata
+        })
+    }
+
+    ```
+
 - `foreignKeys` (optional) - Foreign keys for the database table
 
     Usually, there is no corresponding fields declared in the entity for foreign keys. That is the reason it is necessary to inform the name and the type of the fields.


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->
Updated the documentation to show the ids property is optional, since the entity is provided and has some id defined on it.

Fixes #123 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Provided feature documentation

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
